### PR TITLE
Explicitly control colors output with colorama

### DIFF
--- a/src/wast/_logging.py
+++ b/src/wast/_logging.py
@@ -67,7 +67,7 @@ def _create_handler(output: WriterProtocol) -> logging.Handler:
 
 def setup_logging(level: int, colors: bool) -> None:
     if colors:
-        init()
+        init(strip=False)
         formatter: logging.Formatter = ColorFormatter(
             fmt=(
                 f"{Fore.CYAN}{Style.DIM}wast >{Style.RESET_ALL}"


### PR DESCRIPTION
This allows generating one or multiple coverage reports after pytest and generating a combined report from them