### PR TITLE
Make the docformatter check error out if something is wrong by default

### DIFF
--- a/src/wast/predefined/_docformatter.py
+++ b/src/wast/predefined/_docformatter.py
@@ -14,7 +14,11 @@ from .. import (
 @set_defaults(
     {
         "dependencies": ["docformatter"],
-        "additional_arguments": ["--recursive"],
+        # FIXME: --check does not show the diff on stdout which means it will
+        #        just fail without information.
+        #        https://github.com/PyCQA/docformatter/issues/125
+        #
+        "additional_arguments": ["--recursive", "--check"],
         "files": ["."],
     }
 )


### PR DESCRIPTION
Previously, it would report the required changes on the cli but not exit with a non 0 error code, which leads to confusion.

Sadly, docformatter does not support showing the diff and exit 1 on changes at the same time. See
https://github.com/PyCQA/docformatter/issues/125