### PR TITLE
refactor: Split StepHandler in two

### DIFF
--- a/docs/_extensions/cleanup_signatures.py
+++ b/docs/_extensions/cleanup_signatures.py
@@ -1,0 +1,30 @@
+from typing import Any, Dict, Optional, Tuple
+
+from sphinx.application import Sphinx
+from sphinx.ext.autodoc import Options
+
+
+def cleanup_signatures(  # pylint: disable=unused-argument
+    app: Sphinx,
+    what: str,
+    name: str,
+    obj: Any,
+    options: Options,
+    signature: Optional[str],
+    return_annotation: Optional[str],
+) -> Optional[Tuple[str, Optional[str]]]:
+    if name == "wast.StepRunner":
+        # Hide the __init__ signature for wast.StepRunner, it's meant to be
+        # private
+        return ("()", return_annotation)
+    return None
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    app.connect("autodoc-process-signature", cleanup_signatures)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_inline_tabs",
     "sphinxcontrib.spelling",
+    "cleanup_signatures",
 ]
 
 # Where to store our custom templates
@@ -47,6 +48,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 nitpicky = True
 nitpick_ignore = [
     ("py:class", "wast._steps.parametrize.T"),
+    ("py:class", "wast._steps.handlers.StepHandler"),
 ]
 
 # Theme options

--- a/src/wast/__init__.py
+++ b/src/wast/__init__.py
@@ -16,7 +16,7 @@ from ._steps import (
     MismatchedNumberOfParametersException,
     ParameterConflictException,
     Step,
-    StepHandler,
+    StepRunner,
     StepWithArtifacts,
     StepWithDependentSetup,
     StepWithSetup,
@@ -33,7 +33,7 @@ from ._steps import (
 # XXX: The order here is important, it declares the order in which the entries
 #      are documented in the public docs.
 __all__ = [
-    "StepHandler",
+    "StepRunner",
     "Step",
     "StepWithSetup",
     "StepWithDependentSetup",

--- a/src/wast/_config.py
+++ b/src/wast/_config.py
@@ -27,7 +27,7 @@ class Config:
     The path to the root of the cache directory used by wast.
 
     Note that in most cases, you can use the step-specific cache at
-    :py:attr:`StepHandler.cache_path` and expose data via
+    :py:attr:`StepRunner.cache_path` and expose data via
     :py:func:`StepWithArtifacts.gather_artifacts`.
     """
 

--- a/src/wast/_pipeline.py
+++ b/src/wast/_pipeline.py
@@ -142,10 +142,7 @@ class Pipeline:
             steps = [
                 name
                 for name, step in self._steps.items()
-                # StepHandler is a public interface, we don't want users accessing
-                # this method.
-                # pylint: disable=protected-access
-                if step._run_by_default and name not in except_steps
+                if step.run_by_default and name not in except_steps
             ]
 
         graph = {}
@@ -160,10 +157,8 @@ class Pipeline:
             except KeyError:
                 unknown_steps.append(step)
                 continue
-            # StepHandler is a public interface, we don't want users accessing
-            # this method.
-            # pylint: disable=protected-access
-            required_steps = step_info._requires
+
+            required_steps = step_info.requires
             if only_steps:
                 required_steps = [r for r in required_steps if r in only_steps]
             elif except_steps:
@@ -210,10 +205,7 @@ class Pipeline:
         graph = {
             step: [
                 r
-                # StepHandler is a public interface, we don't want users accessing
-                # this method.
-                # pylint: disable=protected-access
-                for r in self._steps[step]._requires
+                for r in self._steps[step].requires
                 if r in only_steps and r not in except_steps
             ]
             for step in steps
@@ -305,19 +297,13 @@ class Pipeline:
         LOGGER.info("Available steps (* means selected, - means skipped):")
         for step in sorted(all_steps):
             dep_info = ""
-            # StepHandler is a public interface, we don't want users accessing
-            # this method.
-            # pylint: disable=protected-access
-            if show_dependencies and self._steps[step]._requires:
+            if show_dependencies and self._steps[step].requires:
                 dep_info = " --> " + ", ".join(
                     reversed(
                         [
                             s
                             for s in all_steps
-                            # StepHandler is a public interface, we don't want users accessing
-                            # this method.
-                            # pylint: disable=protected-access
-                            if s in self._steps[step]._requires
+                            if s in self._steps[step].requires
                         ]
                     )
                 )
@@ -418,11 +404,8 @@ class Pipeline:
         def total_time() -> timedelta:
             return datetime.now() - start_time
 
-        # StepHandler is a public interface, we don't want users accessing
-        # this method.
-        # pylint: disable=protected-access
         try:
-            self._steps[name]._execute()
+            self._steps[name].execute()
         except UnavailableInterpreterException as exc:
             LOGGER.warning("Step %s failed: %s", name, exc)
             raise ExceptionWithTimeSpentException(exc, total_time()) from exc

--- a/src/wast/_steps/__init__.py
+++ b/src/wast/_steps/__init__.py
@@ -15,7 +15,7 @@ from .registration import (
 )
 from .steps import (
     Step,
-    StepHandler,
+    StepRunner,
     StepWithArtifacts,
     StepWithDependentSetup,
     StepWithSetup,
@@ -31,7 +31,7 @@ __all__ = [
     "set_defaults",
     "step",
     "Step",
-    "StepHandler",
+    "StepRunner",
     "StepWithDependentSetup",
     "StepWithSetup",
     "StepWithArtifacts",

--- a/src/wast/_steps/handlers.py
+++ b/src/wast/_steps/handlers.py
@@ -4,16 +4,19 @@ import re
 import subprocess
 import sys
 from abc import ABC, abstractmethod
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from .._config import Config
 from .._dependency_injection import call_with_parameters
 from .._exceptions import BaseWastException
 from .._runners import VenvRunner
-from .steps import Step
-from .steps import StepHandler as StepHandlerProtocol
-from .steps import StepWithArtifacts, StepWithDependentSetup, StepWithSetup
+from .steps import (
+    Step,
+    StepRunner,
+    StepWithArtifacts,
+    StepWithDependentSetup,
+    StepWithSetup,
+)
 
 if TYPE_CHECKING:
     from .._pipeline import Pipeline
@@ -31,18 +34,20 @@ class BaseStepHandler(ABC):
         run_by_default: Optional[bool] = None,
     ) -> None:
         self.name = name
-        self._requires = requires if requires is not None else []
-        self._run_by_default: bool = (
+        self.requires = requires if requires is not None else []
+        self.run_by_default = (
             run_by_default if run_by_default is not None else True
         )
         self._pipeline = pipeline
 
     @abstractmethod
-    def _execute(self) -> None:
+    def execute(self) -> None:
         pass
 
     @abstractmethod
-    def _execute_dependent_setup(self, current_step: "StepHandler") -> None:
+    def _execute_dependent_setup(
+        self, current_step: "BaseStepHandler"
+    ) -> None:
         pass
 
     @abstractmethod
@@ -54,10 +59,7 @@ class BaseStepHandler(ABC):
         pass
 
 
-class StepHandler(StepHandlerProtocol, BaseStepHandler):
-    # FIXME: should we split the stephandler in two? One for the user-facing
-    #        api, one for the internal parts?
-    #
+class StepHandler(BaseStepHandler):
     def __init__(
         self,
         name: str,
@@ -71,7 +73,6 @@ class StepHandler(StepHandlerProtocol, BaseStepHandler):
         super().__init__(name, pipeline, requires, run_by_default)
 
         self.name = name
-        self._func = func
         if python is None:
             # FIXME: this probably doesn't handle being installed with pypy/pyston
             python = f"python{sys.version_info[0]}.{sys.version_info[1]}"
@@ -81,8 +82,13 @@ class StepHandler(StepHandlerProtocol, BaseStepHandler):
             python = f"python{python}"
 
         self.python = python
+
+        self._func = func
+        self._venv_runner = VenvRunner(self.name, self.python, self.config)
+        self._step_runner = StepRunner(self)
+
         if parameters is None:
-            self.parameters = {"step": self}
+            self.parameters = {"step": self._step_runner}
         else:
             if "step" in parameters:
                 raise BaseWastException(
@@ -90,40 +96,26 @@ class StepHandler(StepHandlerProtocol, BaseStepHandler):
                 )
 
             self.parameters = parameters
-            self.parameters["step"] = self
-
-        self._runner = VenvRunner(self.name, self.python, self.config)
+            self.parameters["step"] = self._step_runner
 
     @property
     def config(self) -> Config:
         return self._pipeline.config
 
-    @property
-    def cache_path(self) -> Path:
-        name = self.name
-        # Those chars regularly cause trouble with unescaped glob patterns and
-        # such. As such, replace them with "-", hoping this does not cause
-        # collisions
-        for char in ["/", ":", "*", "[", "]"]:
-            name = name.replace(char, "-")
-
-        return self.config.cache_path / "cache" / name
-
     def get_artifacts(self, key: str) -> List[Any]:
         return list(
             itertools.chain.from_iterable(
                 [
-                    # StepHandler is a public interface, we don't want users accessing
-                    # this method.
+                    # Pylint check here is wrong, it's still an instance of our class
                     # pylint: disable=protected-access
                     self._pipeline.get_step(requirement)._get_artifacts(key)
-                    for requirement in self._requires
+                    for requirement in self.requires
                 ]
             )
         )
 
     def install(self, *packages: str) -> None:
-        self._runner.install(*packages)
+        self._venv_runner.install(*packages)
 
     def run(
         self,
@@ -133,18 +125,18 @@ class StepHandler(StepHandlerProtocol, BaseStepHandler):
         external_command: bool = False,
         silent_on_success: bool = False,
     ) -> subprocess.CompletedProcess[None]:
-        return self._runner.run(
+        return self._venv_runner.run(
             command,
             env=env,
             external_command=external_command,
             silent_on_success=silent_on_success,
         )
 
-    def _execute(self) -> None:
+    def execute(self) -> None:
         if self.config.skip_setup:
             LOGGER.debug("Skipping setup phase")
         else:
-            self._runner.prepare()
+            self._venv_runner.prepare()
 
             if isinstance(self._func, StepWithSetup):
                 call_with_parameters(self._func.setup, self.parameters.copy())
@@ -153,18 +145,26 @@ class StepHandler(StepHandlerProtocol, BaseStepHandler):
             LOGGER.debug("Skipping run")
             return
 
-        for requirement in self._requires:
-            # StepHandler is a public interface, we don't want users accessing
-            # this method.
+        for requirement in self.requires:
+            # Pylint check here is wrong, it's still an instance of our class
             # pylint: disable=protected-access
             self._pipeline.get_step(requirement)._execute_dependent_setup(self)
 
         call_with_parameters(self._func, self.parameters.copy())
 
-    def _execute_dependent_setup(self, current_step: "StepHandler") -> None:
+    def _execute_dependent_setup(
+        self, current_step: "BaseStepHandler"
+    ) -> None:
+        assert isinstance(current_step, StepHandler)
+
         if isinstance(self._func, StepWithDependentSetup):
             LOGGER.debug("Injecting dependency setup from %s", self.name)
-            self._func.setup_dependent(self, current_step)
+            self._func.setup_dependent(
+                self._step_runner,
+                # Pylint check here is wrong, it's still an instance of our class
+                # pylint: disable=protected-access
+                current_step._step_runner,
+            )
 
     def _get_artifacts(self, key: str) -> List[Any]:
         artifacts = self._gather_artifacts().get(key, [])
@@ -181,17 +181,18 @@ class StepHandler(StepHandlerProtocol, BaseStepHandler):
             LOGGER.debug("Step %s does not provide any artifacts", self.name)
             return {}
 
-        return self._func.gather_artifacts(self)
+        return self._func.gather_artifacts(self._step_runner)
 
 
 class StepGroupHandler(BaseStepHandler):
-    def _execute(self) -> None:
+    def execute(self) -> None:
         LOGGER.debug("Step %s is a meta step. Nothing to do", self.name)
 
-    def _execute_dependent_setup(self, current_step: "StepHandler") -> None:
-        for requirement in self._requires:
-            # StepHandler is a public interface, we don't want users accessing
-            # this method.
+    def _execute_dependent_setup(
+        self, current_step: "BaseStepHandler"
+    ) -> None:
+        for requirement in self.requires:
+            # Pylint check here is wrong, it's still an instance of our class
             # pylint: disable=protected-access
             self._pipeline.get_step(requirement)._execute_dependent_setup(
                 current_step
@@ -201,11 +202,10 @@ class StepGroupHandler(BaseStepHandler):
         return list(
             itertools.chain.from_iterable(
                 [
-                    # StepHandler is a public interface, we don't want users accessing
-                    # this method.
+                    # Pylint check here is wrong, it's still an instance of our class
                     # pylint: disable=protected-access
                     self._pipeline.get_step(requirement)._get_artifacts(key)
-                    for requirement in self._requires
+                    for requirement in self.requires
                 ]
             )
         )

--- a/src/wast/_steps/parametrize.py
+++ b/src/wast/_steps/parametrize.py
@@ -162,7 +162,7 @@ def parametrize(
         @step()
         # This step needs to run for both python 3.10 and python3.11
         @parametrize("python", ["3.10", "3.11"])
-        def print_python_version(step: StepHandler) -> None:
+        def print_python_version(step: StepRunner) -> None:
             step.execute([self.python, "--version"])
 
     Or you might want to parametrize multiple arguments at once. In that case
@@ -185,7 +185,7 @@ def parametrize(
                 ["3.11", ["django==4.0"]],
             ],
         )
-        def test(step: StepHandler) -> None:
+        def test(step: StepRunner) -> None:
             step.run([self.python, "manage.py", "test"])
 
     And finally, you can also combine multiple parametrize calls:
@@ -201,7 +201,7 @@ def parametrize(
         #   - both against django 3.0 and 4.0
         @parametrize("python", ["3.10", "3.11"])
         @parametrize("dependencies", [["django==3.0"], ["django==4.0"]])
-        def test(step: StepHandler) -> None:
+        def test(step: StepRunner) -> None:
             step.run([self.python, "manage.py", "test"])
     """
 

--- a/src/wast/_steps/registration.py
+++ b/src/wast/_steps/registration.py
@@ -4,8 +4,7 @@ from .._exceptions import BaseWastException
 from .._inspect import get_location
 from .._pipeline import get_pipeline
 from .parametrize import build_parameters, parametrize
-from .steps import Step
-from .steps import StepHandler as StepHandlerProtocol
+from .steps import Step, StepRunner
 
 
 def register_step(
@@ -39,7 +38,7 @@ def register_step(
 
             .. code-block::
 
-                def my_step(step: StepHandler): ...
+                def my_step(step: StepRunner): ...
 
                 register_step(my_step)
 
@@ -130,7 +129,7 @@ def register_managed_step(
         )
 
     # pylint: disable=redefined-outer-name
-    def install(step: StepHandlerProtocol, dependencies: str) -> None:
+    def install(step: StepRunner, dependencies: str) -> None:
         step.install(*dependencies)
 
     setattr(func, "setup", install)

--- a/src/wast/_steps/steps.py
+++ b/src/wast/_steps/steps.py
@@ -4,6 +4,7 @@
 import subprocess
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -14,6 +15,9 @@ from typing import (
 )
 
 from .._config import Config
+
+if TYPE_CHECKING:
+    from .handlers import StepHandler
 
 
 @runtime_checkable
@@ -37,7 +41,7 @@ class Step(Protocol):
         .. code-block::
 
             @step()
-            def my_step(step: StepHandler) -> None:
+            def my_step(step: StepRunner) -> None:
                 step.run(["echo", "hello!"])
 
         Or a class:
@@ -46,7 +50,7 @@ class Step(Protocol):
 
             # NOTE: you don't need to explicitely inherit from `Step`
             class MyStep:
-                def __call__(self, step: StepHandler) -> None:
+                def __call__(self, step: StepRunner) -> None:
                     step.run(["echo", "hello!"])
 
             register_step(MyStep(), name="my_step")
@@ -80,7 +84,7 @@ class Step(Protocol):
             Parameters will then be passed using parametrization, with a few specific
             parameters being reserved by the system. Namely:
 
-            - ``step``, which is used to pass the :py:class:`StepHandler`.
+            - ``step``, which is used to pass the :py:class:`StepRunner`.
 
             For passing other arguments, see :py:func:`wast.parametrize` and
             :py:func:`wast.set_defaults`.
@@ -122,10 +126,10 @@ class StepWithSetup(Step, Protocol):
             .. code-block::
 
                 @step()
-                def pytest(step: StepHandler) -> None:
+                def pytest(step: StepRunner) -> None:
                     step.run(["pytest"])
 
-                def install_dependencies(step: StepHandler) -> None:
+                def install_dependencies(step: StepRunner) -> None:
                     step.run(["pip", "install", "pytest"])
 
                 pytest.setup = install_dependencies
@@ -135,10 +139,10 @@ class StepWithSetup(Step, Protocol):
             .. code-block::
 
                 class Pytest:
-                    def setup(self, step: StepHandler) -> None:
+                    def setup(self, step: StepRunner) -> None:
                         step.run(["pip", "install", "pytest"])
 
-                    def __call__(self, step: StepHandler) -> None:
+                    def __call__(self, step: StepRunner) -> None:
                         step.run(["pytest"])
 
                 register_step(Pytest(), name="pytest")
@@ -198,10 +202,10 @@ class StepWithDependentSetup(Step, Protocol):
             .. code-block::
 
                 @managed_step(dependencies=["build"])
-                def package(step: StepHandler) -> None:
+                def package(step: StepRunner) -> None:
                     step.run([step.python, "-m", "build", f"--outdir={step.cache_path}"])
 
-                def install(self, original_step: StepHandler, current_step: StepHandler) -> None:
+                def install(self, original_step: StepRunner, current_step: StepRunner) -> None:
                     wheels = list(original_step.cache_path.glob("*.whl"))
                     # Assuming this is a universal wheel
                     assert len(wheels) == 1
@@ -215,7 +219,7 @@ class StepWithDependentSetup(Step, Protocol):
 
                 # This can now be used as a dependency
                 @step(requires=["package"])
-                def my_step(step: StepHandler) -> None:
+                def my_step(step: StepRunner) -> None:
                     step.run(["myproject", "--help"])
 
         .. tab:: Using a class
@@ -223,13 +227,13 @@ class StepWithDependentSetup(Step, Protocol):
             .. code-block::
 
                 class Package:
-                    def __call__(step: StepHandler) -> None:
+                    def __call__(step: StepRunner) -> None:
                         step.run([step.python, "-m", "build", f"--outdir={step.cache_path}"])
 
                     def setup_dependent(
                         self,
-                        original_step: StepHandler,
-                        current_step: StepHandler,
+                        original_step: StepRunner,
+                        current_step: StepRunner,
                     ) -> None:
                         wheels = list(original_step.cache_path.glob("*.whl"))
                         # Assuming this is a universal wheel
@@ -244,14 +248,14 @@ class StepWithDependentSetup(Step, Protocol):
 
                 # This can now be used as a dependency
                 @step(requires=["package"])
-                def my_step(step: StepHandler) -> None:
+                def my_step(step: StepRunner) -> None:
                     step.run(["myproject", "--help"])
     """
 
     def setup_dependent(
         self,
-        original_step: "StepHandler",
-        current_step: "StepHandler",
+        original_step: "StepRunner",
+        current_step: "StepRunner",
     ) -> None:
         """
         Run some logic into a dependent step.
@@ -273,7 +277,7 @@ class StepWithArtifacts(Step, Protocol):
     want to aggregate them together.
 
     This allows a programmatic interface between steps to access artifacts.
-    See :py:func:`StepHandler.get_artifacts` for how to retrieve those artifacts
+    See :py:func:`StepRunner.get_artifacts` for how to retrieve those artifacts
     from another step.
 
     :Examples:
@@ -292,7 +296,7 @@ class StepWithArtifacts(Step, Protocol):
 
                 @step()
                 @parametrize(python=["3.9", "3.10"])
-                def pytest(step: StepHandler) -> None:
+                def pytest(step: StepRunner) -> None:
                     step.run(
                         ["pytest"],
                         env={
@@ -302,7 +306,7 @@ class StepWithArtifacts(Step, Protocol):
                         },
                     )
 
-                def gather_artifacts(step: "StepHandler") -> Dict[str, List[Any]]:
+                def gather_artifacts(step: "StepRunner") -> Dict[str, List[Any]]:
                     return step.cache_path.joinpath(step.python, "coverage")
 
                 pytest.gather_artifacts = gather_artifacts
@@ -312,13 +316,13 @@ class StepWithArtifacts(Step, Protocol):
             .. code-block::
 
                 class Pytest:
-                    def _get_coverage_file(self, step: StepHandler) -> str:
+                    def _get_coverage_file(self, step: StepRunner) -> str:
                         return str(step.cache_path / "reports" / "coverage")
 
-                    def gather_artifacts(self, step: StepHandler) -> Dict[str, List[Any]]:
+                    def gather_artifacts(self, step: StepRunner) -> Dict[str, List[Any]]:
                         return {"coverage_files": [self._get_coverage_file(step)]}
 
-                    def __call__(self, step: StepHandler) -> None:
+                    def __call__(self, step: StepRunner) -> None:
                         step.run(
                             ["pytest", *args],
                             env={"COVERAGE_FILE": self._get_coverage_file(step)},
@@ -331,7 +335,7 @@ class StepWithArtifacts(Step, Protocol):
         .. code-block::
 
             @managed_step(dependencies=["coverage"], requires=["pytest"])
-            def coverage(self, step: StepHandler) -> None:
+            def coverage(self, step: StepRunner) -> None:
                 env = {"COVERAGE_FILE": str(step.cache_path / "coverage")}
 
                 coverage_files = step.get_artifacts("coverage_files")
@@ -344,7 +348,7 @@ class StepWithArtifacts(Step, Protocol):
         .. tip:: The :py:func:`wast.predefined.coverage` step does roughly this.
     """
 
-    def gather_artifacts(self, step: "StepHandler") -> Dict[str, List[Any]]:
+    def gather_artifacts(self, step: "StepRunner") -> Dict[str, List[Any]]:
         """
         Gather all artifacts exposed by this step.
 
@@ -355,9 +359,9 @@ class StepWithArtifacts(Step, Protocol):
         """
 
 
-class StepHandler:
+class StepRunner:
     """
-    Defines the manager for a :term:`step`, and provides utilities for the step to run.
+    Defines the runner for a :term:`step`, and provides utilities for the step to run.
 
     This is passed as an argument to every step that executes as ``step``.
 
@@ -365,15 +369,24 @@ class StepHandler:
     standardized environment.
     """
 
-    name: str
-    """The name of the current step"""
+    def __init__(self, handler: "StepHandler") -> None:
+        self._handler = handler
 
-    python: str
-    """
-    The name of the current python interpreter
+    @property
+    def name(self) -> str:
+        """
+        The name of the current step.
+        """
+        return self._handler.name
 
-    .. note:: This is not the absolute path to it, just its name.
-    """
+    @property
+    def python(self) -> str:
+        """
+        The name of the current python interpreter.
+
+        .. note:: This is not the absolute path to it, just its name.
+        """
+        return self._handler.python
 
     @property
     def config(self) -> Config:
@@ -385,6 +398,7 @@ class StepHandler:
         you might want to use the :py:attr:`Config.verbosity` to
         configure the output of some commands you run.
         """
+        return self._handler.config
 
     @property
     def cache_path(self) -> Path:
@@ -395,6 +409,14 @@ class StepHandler:
 
         This will be cleaned up and emptied before the step runs.
         """
+        name = self.name
+        # Those chars regularly cause trouble with unescaped glob patterns and
+        # such. As such, replace them with "-", hoping this does not cause
+        # collisions
+        for char in ["/", ":", "*", "[", "]"]:
+            name = name.replace(char, "-")
+
+        return self.config.cache_path / "cache" / name
 
     def get_artifacts(self, key: str) -> List[Any]:
         """
@@ -414,6 +436,7 @@ class StepHandler:
         :return: A list of artifacts, one per step providing artifacts for the
                  given key.
         """
+        return self._handler.get_artifacts(key)
 
     def install(self, *packages: str) -> None:
         """
@@ -426,6 +449,7 @@ class StepHandler:
 
         :param packages: which packages to install
         """
+        return self._handler.install(*packages)
 
     def run(
         self,
@@ -461,3 +485,9 @@ class StepHandler:
         :return: a :py:class:`subprocess.CompletedProcess` with `stderr` and
                  `stdout` set to ``None``.
         """
+        return self._handler.run(
+            command,
+            env=env,
+            external_command=external_command,
+            silent_on_success=silent_on_success,
+        )

--- a/src/wast/predefined/_black.py
+++ b/src/wast/predefined/_black.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Sequence
 #      users might need it
 from .. import (
     Step,
-    StepHandler,
+    StepRunner,
     build_parameters,
     register_managed_step,
     set_defaults,
@@ -24,7 +24,7 @@ class Black(Step):
 
     def __call__(
         self,
-        step: StepHandler,
+        step: StepRunner,
         files: Sequence[str],
         additional_arguments: List[str],
     ) -> None:

--- a/src/wast/predefined/_coverage.py
+++ b/src/wast/predefined/_coverage.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 #      users might need it
 from .. import (
     Step,
-    StepHandler,
+    StepRunner,
     parametrize,
     register_managed_step,
     set_defaults,
@@ -23,7 +23,7 @@ class Coverage(Step):
 
     def __call__(
         self,
-        step: StepHandler,
+        step: StepRunner,
         reports: List[List[str]],
     ) -> None:
         env = {"COVERAGE_FILE": str(step.cache_path / "coverage")}

--- a/src/wast/predefined/_docformatter.py
+++ b/src/wast/predefined/_docformatter.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Sequence
 #      users might need it
 from .. import (
     Step,
-    StepHandler,
+    StepRunner,
     build_parameters,
     register_managed_step,
     set_defaults,
@@ -28,7 +28,7 @@ class DocFormatter(Step):
 
     def __call__(
         self,
-        step: StepHandler,
+        step: StepRunner,
         files: Sequence[str],
         additional_arguments: List[str],
     ) -> None:

--- a/src/wast/predefined/_isort.py
+++ b/src/wast/predefined/_isort.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Sequence
 #      users might need it
 from .. import (
     Step,
-    StepHandler,
+    StepRunner,
     build_parameters,
     register_managed_step,
     set_defaults,
@@ -24,7 +24,7 @@ class Isort(Step):
 
     def __call__(
         self,
-        step: StepHandler,
+        step: StepRunner,
         files: Sequence[str],
         additional_arguments: List[str],
     ) -> None:

--- a/src/wast/predefined/_mypy.py
+++ b/src/wast/predefined/_mypy.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Sequence
 #      users might need it
 from .. import (
     Step,
-    StepHandler,
+    StepRunner,
     build_parameters,
     register_managed_step,
     set_defaults,
@@ -24,7 +24,7 @@ class Mypy(Step):
 
     def __call__(
         self,
-        step: StepHandler,
+        step: StepRunner,
         files: Sequence[str],
         additional_arguments: List[str],
     ) -> None:

--- a/src/wast/predefined/_package.py
+++ b/src/wast/predefined/_package.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Sequence
 #      users might need it
 from .. import (
     Step,
-    StepHandler,
+    StepRunner,
     StepWithDependentSetup,
     parametrize,
     register_managed_step,
@@ -19,7 +19,7 @@ class Package(StepWithDependentSetup):
     def __init__(self) -> None:
         self.__name__ = "package"
 
-    def gather_artifacts(self, step: StepHandler) -> Dict[str, List[Any]]:
+    def gather_artifacts(self, step: StepRunner) -> Dict[str, List[Any]]:
         artifacts = {}
         sdists = [str(p) for p in step.cache_path.glob("*.tar.gz")]
         if sdists:
@@ -32,7 +32,7 @@ class Package(StepWithDependentSetup):
         return artifacts
 
     def setup_dependent(
-        self, original_step: StepHandler, current_step: StepHandler
+        self, original_step: StepRunner, current_step: StepRunner
     ) -> None:
         wheels = list(original_step.cache_path.glob("*.whl"))
         assert len(wheels) == 1
@@ -42,7 +42,7 @@ class Package(StepWithDependentSetup):
             silent_on_success=current_step.config.verbosity < 2,
         )
 
-    def __call__(self, step: StepHandler, isolate: bool) -> None:
+    def __call__(self, step: StepRunner, isolate: bool) -> None:
         with suppress(FileNotFoundError):
             shutil.rmtree(step.cache_path)
 

--- a/src/wast/predefined/_pylint.py
+++ b/src/wast/predefined/_pylint.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Sequence
 #      users might need it
 from .. import (
     Step,
-    StepHandler,
+    StepRunner,
     build_parameters,
     register_managed_step,
     set_defaults,
@@ -24,7 +24,7 @@ class Pylint(Step):
 
     def __call__(
         self,
-        step: StepHandler,
+        step: StepRunner,
         files: Sequence[str],
         additional_arguments: List[str],
     ) -> None:

--- a/src/wast/predefined/_pytest.py
+++ b/src/wast/predefined/_pytest.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Sequence
 
 # XXX: All imports here should be done from the top level. If we need it,
 #      users might need it
-from .. import Step, StepHandler
+from .. import Step, StepRunner
 from .. import parametrize as apply_parameters
 from .. import register_managed_step, set_defaults
 
@@ -16,20 +16,20 @@ class Pytest(Step):
     def __init__(self) -> None:
         self.__name__ = "pytest"
 
-    def gather_artifacts(self, step: StepHandler) -> Dict[str, List[Any]]:
+    def gather_artifacts(self, step: StepRunner) -> Dict[str, List[Any]]:
         coverage_file = self._get_coverage_file(step)
         if coverage_file is None or not coverage_file.exists():
             return {}
 
         return {"coverage_files": [str(coverage_file)]}
 
-    def __call__(self, step: StepHandler, args: Sequence[str]) -> None:
+    def __call__(self, step: StepRunner, args: Sequence[str]) -> None:
         step.run(
             ["pytest", *args],
             env={"COVERAGE_FILE": str(self._get_coverage_file(step))},
         )
 
-    def _get_coverage_file(self, step: StepHandler) -> Path:
+    def _get_coverage_file(self, step: StepRunner) -> Path:
         return step.cache_path / "reports" / "coverage"
 
 

--- a/src/wast/predefined/_sphinx.py
+++ b/src/wast/predefined/_sphinx.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 
 from .. import (
     Step,
-    StepHandler,
+    StepRunner,
     build_parameters,
     register_managed_step,
     set_defaults,
@@ -25,7 +25,7 @@ class Sphinx(Step):
 
     def __call__(
         self,
-        step: StepHandler,
+        step: StepRunner,
         builder: str,
         sourcedir: Union[Path, str],
         output: Optional[Union[Path, str]],

--- a/src/wast/predefined/_twine.py
+++ b/src/wast/predefined/_twine.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 #      users might need it
 from .. import (
     Step,
-    StepHandler,
+    StepRunner,
     build_parameters,
     register_managed_step,
     set_defaults,
@@ -28,7 +28,7 @@ class Twine(Step):
 
     def __call__(
         self,
-        step: StepHandler,
+        step: StepRunner,
         additional_arguments: List[str],
         passenv: List[str],
     ) -> None:

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -13,14 +13,12 @@ from ._utils import isolated_context
 
 
 def _get_all_steps_from_pipeline(pipeline: Pipeline) -> Dict[str, Any]:
-    # We are testing some internals here
-    # pylint: disable=protected-access
     def _format_step(step: BaseStepHandler) -> Dict[str, Any]:
         if isinstance(step, StepGroupHandler):
             return {
                 "type": "group",
-                "requires": step._requires,
-                "run_by_default": step._run_by_default,
+                "requires": step.requires,
+                "run_by_default": step.run_by_default,
             }
 
         assert isinstance(step, StepHandler)
@@ -32,11 +30,13 @@ def _get_all_steps_from_pipeline(pipeline: Pipeline) -> Dict[str, Any]:
 
         return {
             "python": step.python,
-            "run_by_default": step._run_by_default,
-            "requires": step._requires,
+            "run_by_default": step.run_by_default,
+            "requires": step.requires,
             "parameters": parameters,
         }
 
+    # We are testing some internals here
+    # pylint: disable=protected-access
     pipeline._resolve_steps()
     return {key: _format_step(step) for key, step in pipeline._steps.items()}
 


### PR DESCRIPTION
StepHandler had a lot of private methods that were meant for wast to call, which makes it harder to cleanly design. Splitting it into a StepRunner, which is part of the public API, and a StepHandler, which is for internal allows a simpler separation of concerns and allows us to encapsulate this class better