### PR TITLE
Add a predefined step to run unimport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - isort
           - mypy
           - pylint
+          - unimport
 
     steps:
       - name: Check out repository

--- a/docs/_spelling_allowlist.txt
+++ b/docs/_spelling_allowlist.txt
@@ -6,6 +6,7 @@ conda
 cpus
 cpython
 doctests
+enqueuing
 isort
 linkchecks
 nox
@@ -18,5 +19,5 @@ pytest
 reusability
 sdist
 tox
+unimport
 venvs
-enqueuing

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,6 +93,7 @@ rst_epilog = """
 .. _pytest: https://docs.pytest.org/en/stable/
 .. _sphinx:  https://www.sphinx-doc.org/
 .. _twine: https://twine.readthedocs.io/en/stable/
+.. _the Unimport formatter: https://unimport.hakancelik.dev/
 .. _the manylinux project: https://github.com/pypa/manylinux
 .. _github actions: https://github.com/features/actions
 """

--- a/src/wast/predefined/__init__.py
+++ b/src/wast/predefined/__init__.py
@@ -24,6 +24,7 @@ from ._pylint import pylint
 from ._pytest import pytest
 from ._sphinx import sphinx
 from ._twine import twine
+from ._unimport import unimport
 
 __all__ = [
     "black",
@@ -36,4 +37,5 @@ __all__ = [
     "pytest",
     "sphinx",
     "twine",
+    "unimport",
 ]

--- a/src/wast/predefined/_unimport.py
+++ b/src/wast/predefined/_unimport.py
@@ -1,0 +1,143 @@
+import re
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+# XXX: All imports here should be done from the top level. If we need it,
+#      users might need it
+from .. import (
+    Step,
+    StepRunner,
+    build_parameters,
+    register_managed_step,
+    set_defaults,
+)
+
+
+@set_defaults(
+    {
+        "dependencies": ["unimport"],
+        "files": ["."],
+        "additional_arguments": ["--check", "--diff", "--gitignore"],
+    }
+)
+class Unimport(Step):
+    def __init__(self) -> None:
+        self.__name__ = "unimport"
+
+    def __call__(
+        self,
+        step: StepRunner,
+        files: Sequence[str],
+        additional_arguments: List[str],
+    ) -> None:
+        if not any(arg.startswith("--color") for arg in additional_arguments):
+            color_arg = (
+                f"--color={'always' if step.config.colors else 'never'}"
+            )
+            additional_arguments.append(color_arg)
+
+        try:
+            subpath = step.config.cache_path.relative_to(Path.cwd())
+        except ValueError:
+            pass
+        else:
+            additional_arguments.append(
+                f"--exclude=^{re.escape(str(subpath))}"
+            )
+
+        step.run(["unimport", *additional_arguments, *files])
+
+
+def unimport(
+    *,
+    name: Optional[str] = None,
+    files: Optional[Sequence[str]] = None,
+    additional_arguments: Optional[List[str]] = None,
+    python: Optional[str] = None,
+    requires: Optional[List[str]] = None,
+    dependencies: Optional[List[str]] = None,
+    run_by_default: Optional[bool] = None,
+) -> Step:
+    """
+    Run `the Unimport formatter`_ against your python source code.
+
+    If the `wast` cache is part of the running directory, it will automatically
+    get ignored.
+
+    :param name: The name to give to the step.
+                 Defaults to :python:`"unimport"`.
+    :param files: The list of files or directories to run ``unimport`` against.
+                  Defaults to :python:`["."]`.
+    :param additional_arguments: Additional arguments to pass to the ``unimport``
+                                 invocation.
+                                 Defaults to :python:`["--check", "--diff", "--gitignore"]`.
+    :param python: The version of python to use.
+                   Defaults to the version *wast* was installed with.
+    :param requires: A list of other steps that this step would require.
+    :param dependencies: Python dependencies needed to run this step.
+                         Defaults to :python:`["unimport"]`.
+    :param run_by_default: Whether to run this step by default or not.
+                           Defaults to :python:`True`.
+    :return: The step so that you can add additional parameters to it if needed.
+
+    :Examples:
+
+        In order to verify your code but not change it, for a step
+        named **unimport**:
+
+        .. code-block::
+
+            wast.predefined.unimport()
+
+        Or, in order to automatically fix your code, but only if requested:
+
+        .. code-block::
+
+            wast.predefined.unimport(
+                # Note: this name is arbitrary, you could omit it, or specify
+                #       something else. We suffix in our documentation all
+                #       operations that will have destructive effect on the source
+                #       code by ``:fix``
+                name="unimport:fix",
+                # NOTE: `--gitignore` here is not required, but probably a good idea
+                additional_arguments=["--remove", "--gitignore"],
+                run_by_default=False,
+            )
+
+        Note that if you have other steps that will overwrite some of your files,
+        you might want to order them so they don't conflict. For example, assuming
+        that you also use :py:func:`wast.predefined.isort`:
+
+        .. code-block::
+
+            wast.predefined.unimport(
+                name="unimport:fix",
+                # NOTE: `--gitignore` here is not required, but probably a good idea
+                additional_arguments=["--remove", "--gitignore"],
+                run_by_default=False,
+            )
+            wast.predefined.isort(
+                name="isort:fix",
+                additional_arguments=["--atomic"],
+                requires=["unimport:fix"],
+                run_by_default=False,
+            )
+
+        This will ensure that both steps don't step on each other and make
+        unimport run first.
+    """
+
+    unimport_ = Unimport()
+
+    unimport_ = build_parameters(
+        files=files, additional_arguments=additional_arguments
+    )(unimport_)
+
+    return register_managed_step(
+        unimport_,
+        dependencies,
+        name=name,
+        python=python,
+        requires=requires,
+        run_by_default=run_by_default,
+    )

--- a/tests/predefined/test_unimport.py
+++ b/tests/predefined/test_unimport.py
@@ -1,0 +1,108 @@
+import pytest
+
+
+def test_does_not_modify_files_by_default(cli, tmp_path):
+    # This code is misformatted to trigger an error
+    wastfile_content = """\
+from wast.predefined import unimport
+import os
+
+unimport()
+"""
+    wastfile_path = tmp_path.joinpath("wastfile.py")
+    wastfile_path.write_text(wastfile_content)
+
+    result = cli([], raise_on_error=False)
+    assert result.exit_code == 1
+
+    assert wastfile_path.read_text() == wastfile_content
+
+
+def test_can_apply_fixes(cli, tmp_path):
+    # This code is misformatted to trigger an error
+    wastfile_content = """\
+from wast.predefined import unimport
+import os
+
+unimport(additional_arguments=["--diff", "--remove", "--check"])
+"""
+    wastfile_path = tmp_path.joinpath("wastfile.py")
+    wastfile_path.write_text(wastfile_content)
+
+    cli([])
+    assert wastfile_path.read_text() != wastfile_content
+
+
+@pytest.mark.parametrize(
+    "set_cache", [False, True], ids=["default-cache", "provided-cache"]
+)
+def test_cache_is_automatically_ignored(cli, tmp_path, set_cache):
+    wastfile_content = """\
+from wast.predefined import unimport
+
+unimport()
+"""
+    wastfile_path = tmp_path.joinpath("wastfile.py")
+    wastfile_path.write_text(wastfile_content)
+
+    args = []
+
+    # Create a misformatted file in the cache
+    if set_cache:
+        cache_path = tmp_path / "cache"
+        args.extend(["--cache-path", str(cache_path)])
+    else:
+        cache_path = tmp_path / ".wast"
+
+    cache_path.mkdir()
+    cache_path.joinpath("misformated.py").write_text("import os")
+
+    cli(args)
+
+
+@pytest.mark.parametrize(
+    "set_cache", [False, True], ids=["default-cache", "provided-cache"]
+)
+def test_non_cache_with_same_name_is_not_ignored(cli, tmp_path, set_cache):
+    wastfile_content = """\
+from wast.predefined import unimport
+
+unimport()
+"""
+    wastfile_path = tmp_path.joinpath("wastfile.py")
+    wastfile_path.write_text(wastfile_content)
+
+    args = []
+
+    # Create a misformatted file in the cache
+    if set_cache:
+        cache_path = tmp_path / "cache"
+        args.extend(["--cache-path", str(cache_path)])
+    else:
+        cache_path = tmp_path / ".wast"
+
+    not_cache_path = tmp_path / "not-the-cache" / cache_path.name
+    not_cache_path.mkdir(parents=True)
+    not_cache_path.joinpath("misformated.py").write_text("import os")
+
+    result = cli(args, raise_on_error=False)
+    assert result.exit_code == 1
+
+
+def test_does_not_exclude_cache_if_not_relative(
+    cli, tmp_path, tmp_path_factory
+):
+    wastfile_content = """\
+from wast.predefined import unimport
+
+unimport()
+"""
+    wastfile_path = tmp_path.joinpath("wastfile.py")
+    wastfile_path.write_text(wastfile_content)
+
+    cache_path = tmp_path_factory.mktemp("cache")
+
+    # cache_path.mkdir()
+    # cache_path.joinpath("misformated.py").write_text("import os")
+
+    cli(["--cache-path", str(cache_path)])

--- a/wastfile.py
+++ b/wastfile.py
@@ -19,16 +19,23 @@ ARTIFACTS_PATH = ROOT_PATH / "_artifacts"
 ##
 # Formatting
 ##
+wast.predefined.unimport()
 wast.predefined.isort(files=PYTHON_FILES)
 wast.predefined.docformatter(files=PYTHON_FILES)
 wast.predefined.black()
 
 # With auto fix
+wast.predefined.unimport(
+    name="unimport:fix",
+    additional_arguments=["--diff", "--remove", "--check", "--gitignore"],
+    run_by_default=False,
+)
 wast.predefined.isort(
     name="isort:fix",
     additional_arguments=["--atomic"],
     run_by_default=False,
     files=PYTHON_FILES,
+    requires=["unimport:fix"],
 )
 wast.predefined.docformatter(
     name="docformatter:fix",


### PR DESCRIPTION
Unimport can help with automatically removing unused imports, instead of having to go through each file and remove them