### PR TITLE
Fix reporting of blocked tasks, to show all blockers

### DIFF
--- a/src/wast/_pipeline.py
+++ b/src/wast/_pipeline.py
@@ -376,7 +376,9 @@ class Pipeline:
                 cancelled_jobs.append(name)
             else:
                 blocking_dependencies = [
-                    dep for dep in graph[name] if dep in failed_jobs
+                    dep
+                    for dep in graph[name]
+                    if dep in failed_jobs or dep in blocked_jobs
                 ]
                 assert blocking_dependencies is not None
                 blocked_jobs.append(name)


### PR DESCRIPTION
Previously, we would only show the failed tasks as blockers, but a blocked task is itself a blocker for dependants. Also show those in the report.